### PR TITLE
Add avatar upload to profile

### DIFF
--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -105,8 +105,12 @@ export default function Insights() {
               )}
               
               <div className="flex items-center mb-4">
-                <div className="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center text-blue-700 font-bold">
-                  {insight.user?.displayName?.charAt(0) || insight.user?.username?.charAt(0) || '?'}
+                <div className="w-10 h-10 rounded-full overflow-hidden bg-blue-100 flex items-center justify-center text-blue-700 font-bold">
+                  {insight.user?.avatarUrl ? (
+                    <img src={insight.user.avatarUrl} alt="avatar" className="w-full h-full object-cover" />
+                  ) : (
+                    insight.user?.displayName?.charAt(0) || insight.user?.username?.charAt(0) || '?'
+                  )}
                 </div>
                 <div className="mr-3">
                   <div className="font-bold text-gray-900">{insight.user?.displayName || insight.user?.username}</div>

--- a/app/sources/[id]/page.tsx
+++ b/app/sources/[id]/page.tsx
@@ -266,8 +266,12 @@ export default function SourceDetail() {
             {insights.map(insight => (
               <div key={insight.id} className="bg-white p-6 rounded-lg shadow-md">
                 <div className="flex items-center mb-4">
-                  <div className="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center text-blue-700 font-bold">
-                    {insight.user?.displayName?.charAt(0) || insight.user?.username?.charAt(0) || '?'}
+                  <div className="w-10 h-10 rounded-full overflow-hidden bg-blue-100 flex items-center justify-center text-blue-700 font-bold">
+                    {insight.user?.avatarUrl ? (
+                      <img src={insight.user.avatarUrl} alt="avatar" className="w-full h-full object-cover" />
+                    ) : (
+                      insight.user?.displayName?.charAt(0) || insight.user?.username?.charAt(0) || '?'
+                    )}
                   </div>
                   <div className="mr-3">
                     <div className="font-bold text-gray-900">{insight.user?.displayName || insight.user?.username}</div>

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -58,6 +58,12 @@ jest.mock('@/utils/supabase-client', () => ({
         eq: jest.fn(() => Promise.resolve({ data: {}, error: null })),
       })),
     })),
+    storage: {
+      from: jest.fn(() => ({
+        upload: jest.fn(() => Promise.resolve({ data: {}, error: null })),
+        getPublicUrl: jest.fn(() => ({ data: { publicUrl: 'http://example.com/avatar.png' }, error: null })),
+      })),
+    },
   })),
   ToraUser: {},
   Source: {},


### PR DESCRIPTION
## Summary
- support uploading profile avatar to Supabase storage
- show avatar on profile page
- display avatar images on insights and sources pages
- extend Jest mocks with Supabase storage

## Testing
- `npm test`
- `npx cypress run --spec "cypress/e2e/*.cy.ts" --headless` *(fails: Xvfb missing)*